### PR TITLE
Update for InkScape 1.0

### DIFF
--- a/ofsplot.inx
+++ b/ofsplot.inx
@@ -1,23 +1,26 @@
 <inkscape-extension>
-  <_name>Offset Plot</_name>
-  <id>org.ofsplot</id>
-  <dependency type="executable" location="extensions">ofsplot.py</dependency>
-  <param name="count" type="int" min="0" max="100000" _gui-text="Number of offset paths:">10</param>
-  <param name="ofs" type="float" min="-1000" max="+1000"  _gui-text="Offset between two paths:">0.8</param>
-  <param name="init_ofs" type="float" min="-1000" max="+1000"  _gui-text="Initial offset from original path:">0.8</param>
-  <param name="copy_org" type="boolean" _gui-text="Copy original path (=keep it)">0</param>
-  <param name="ofs_incr" type="float" min="-1000" max="+1000"  _gui-text="Offset increase per iteration:">0.8</param>
-  <_param name="settingsHelp" type="description">Python library pyclipper needs to be installed. Use Flatten Bezier plugin in advance of this plugin.</_param>
-    
-
-  <effect>
-    <object-type>all</object-type>
+    <name>Offset Plot</name>
+    <id>org.ofsplot</id>
+    <param name="count" type="int" min="0" max="100000" gui-text="Number of offset paths:">10</param>
+    <param name="offset" type="float" min="-1000" max="+1000" gui-text="Offset between two paths:">0.8</param>
+    <param name="init_offset" type="float" min="-1000" max="+1000" gui-text="Initial offset from original path:">0.8</param>
+    <param name="copy_org" type="bool" gui-text="Copy original path (=keep it)">false</param>
+    <param name="offset_increase" type="float" min="-1000" max="+1000" gui-text="Offset increase per iteration:">0.8</param>
+    <param name="miterlimit" type="float" min="0.0" max="1000" gui-text="Miter limit">3.0</param>
+    <param name="clipperscale" type="float" min="0.0" max="9999.0" gui-text="Scaling factor">1024.0</param>
+    <param name="jointype" appearance="combo" type="optiongroup" default="2" gui-text="Join type">
+        <option value="0">Square</option>
+        <option value="1">Round</option>
+        <option value="2">Miter</option>
+    </param>
+    <param name="settingsHelp" type="description">Python library pyclipper needs to be installed. Use Flatten Bezier plugin in advance of this plugin.</param>
+    <effect>
+        <object-type>all</object-type>
     <effects-menu>
-       <submenu _name="Modify Path"/>
+       <submenu name="Modify Path"/>
     </effects-menu>
-  </effect>
-  <script>
-    <command reldir="extensions" interpreter="python">ofsplot.py</command>
-  </script>
+    </effect>
+    <script>
+        <command location="inx" interpreter="python">ofsplot.py</command>
+    </script>
 </inkscape-extension>
-

--- a/ofsplot.py
+++ b/ofsplot.py
@@ -1,56 +1,30 @@
-#!/usr/bin/env python
-from __future__ import print_function
+#!/usr/bin/env python3
 
 import inkex
-import cubicsuperpath, simplestyle, copy, math, re, bezmisc, simplepath
+import math
+from inkex.paths import CubicSuperPath
+import re
 import pyclipper
-import sys
-
-def eprint(*args, **kwargs):
-    print(*args, file=sys.stderr, **kwargs)
-
-
 
 class ofsplot(inkex.Effect):
     def __init__(self):
         inkex.Effect.__init__(self)
-        self.OptionParser.add_option("--count",
-                        action="store", type="int",
-                        dest="count", default=10,
-                        help="Number of offset operations")
-        self.OptionParser.add_option("--ofs",
-                        action="store", type="float",
-                        dest="offset", default=2,
-                        help="Offset amount")
-        self.OptionParser.add_option("--init_ofs",
-                        action="store", type="float",
-                        dest="init_offset", default=2,
-                        help="Initial Offset Amount")
-        self.OptionParser.add_option("--copy_org",
-                        action="store", type="inkbool",
-                        dest="copy_org", default=True,
-                        help="copy original path")
-        self.OptionParser.add_option("--ofs_incr",
-                        action="store", type="float",
-                        dest="offset_increase", default=2,
-                        help="Offset increase between iterations")
-
-
-
+        self.arg_parser.add_argument("--count", type=int, dest="count", default=10, help="Number of offset operations")
+        self.arg_parser.add_argument("--ofs", type=float, dest="offset", default=2, help="Offset amount")
+        self.arg_parser.add_argument("--init_ofs", type=float, dest="init_offset", default=2, help="Initial Offset Amount")
+        self.arg_parser.add_argument("--copy_org", type=inkex.Boolean, default=True, help="copy original path")
+        self.arg_parser.add_argument("--ofs_incr", type=float, dest="offset_increase", default=2, help="Offset increase between iterations")
 
     def effect(self):
-
-        for id, node in self.selected.iteritems():
+        for id, node in self.svg.selected.items():
             if node.tag == inkex.addNS('path','svg'):
-                p = cubicsuperpath.parsePath(node.get('d'))
+                p = CubicSuperPath(node.get('d'))
 
                 scale_factor=5.0
-
 
                 pco = pyclipper.PyclipperOffset()
                 
                 new = []
-
 
                 # load in initial paths
                 for sub in p:
@@ -60,13 +34,7 @@ class ofsplot(inkex.Effect):
                     for item in sub:
                         itemx = [float(z)*scale_factor for z in item[1]]
                         sub_simple.append(itemx)
-                        #eprint(itemx)
-                        #h1_simple.append(item[0]-item[1]) # handle 1 offset
-                        #h2_simple.append(item[2]-item[1]) # handle 2 offset
-
                     pco.AddPath(sub_simple, pyclipper.JT_ROUND, pyclipper.ET_CLOSEDPOLYGON)
-
-
 
                 # calculate offset paths for different offset amounts
                 offset_list = []
@@ -77,14 +45,12 @@ class ofsplot(inkex.Effect):
                         ofs_inc = -ofs_inc
                     offset_list.append(offset_list[0]+float(i)*self.options.offset+ofs_inc)
 
-
                 solutions = []
                 for offset in offset_list:
                     solution = pco.Execute(offset*scale_factor)
                     solutions.append(solution)
                     if len(solution)<=0:
                         continue # no more loops to go, will provide no results.
-
 
                 # re-arrange solutions to fit expected format & add to array
                 for solution in solutions:
@@ -94,18 +60,12 @@ class ofsplot(inkex.Effect):
                         sol_p.append(sol_p[0][:])
                         new.append(sol_p)
 
-
-
-
                 # add old, just to keep (make optional!)
                 if self.options.copy_org:
                     for sub in p:
                         new.append(sub)
 
-                node.set('d',cubicsuperpath.formatPath(new))
-
+                node.set('d',CubicSuperPath(new))
 
 if __name__ == '__main__':
-    e = ofsplot()
-    e.affect()
-
+    ofsplot().run()


### PR DESCRIPTION
works using Python 3.8.5 as external python interpreter on Windows (inkscape's preferences.xml has to be adjusted). required to use pyclipper library which has C bindings